### PR TITLE
Rename sensor info columns

### DIFF
--- a/egauge/script/api_egauge.py
+++ b/egauge/script/api_egauge.py
@@ -147,7 +147,7 @@ def insert_readings_into_database(conn, readings, purpose_sensors):
                     column_name = columns[i+1]
                     # only insert column's reading if data_sensor_info_mapping matches column_name
                     if purpose_sensor.data_sensor_info_mapping == column_name:
-                        reading_row = orm_egauge.Readings(purpose_id=purpose_sensor.purpose_id, datetime=row_datetime, value=row_reading, units=purpose_sensor.unit)
+                        reading_row = orm_egauge.Reading(purpose_id=purpose_sensor.purpose_id, datetime=row_datetime, reading=row_reading, units=purpose_sensor.unit)
                         conn.add(reading_row)
                         rows_inserted += 1
                         new_last_updated_datetime = row_datetime

--- a/egauge/script/orm_egauge.py
+++ b/egauge/script/orm_egauge.py
@@ -34,7 +34,7 @@ class Project(BASE):
     project_folder_path = Column(String, primary_key=True)
 
 
-class Readings(BASE):
+class Reading(BASE):
     """
     This class represents the readings table
 
@@ -45,12 +45,12 @@ class Readings(BASE):
         purpose_id: unique id representing a purpose
         value: the numerical value of a reading
     """
-    __tablename__ = 'readings'
+    __tablename__ = 'reading'
 
     datetime = Column(TIMESTAMP, primary_key=True)
     purpose_id = Column(Integer, primary_key=True)
-    value = Column(DOUBLE_PRECISION)
     units = Column(String)
+    reading = Column(DOUBLE_PRECISION)
     upload_timestamp = Column(TIMESTAMP, default=func.now())
 
 
@@ -79,13 +79,20 @@ class SensorInfo(BASE):
         webctrl = "webctrl"
 
     purpose_id = Column(Integer, primary_key=True)
-    query_string = Column(String)
-    data_sensor_info_mapping = Column(String)
+    building = Column(String)
+    variable_name = Column(String)
+    unit = Column(String)
     type = Column(String)
+    appliance = Column(String)
+    room = Column(String)
+    surface = Column(String)
+    sample_resolution = Column(String)
+    query_string = Column(String)
+    note = Column(String)
+    data_sensor_info_mapping = Column(String)
     script_folder = Column(Enum(ScriptFolderEnum))
     is_active = Column(Boolean)
     last_updated_datetime = Column(TIMESTAMP)
-    unit = Column(String)
 
 
 class ErrorLog(BASE):

--- a/egauge/script/orm_egauge.py
+++ b/egauge/script/orm_egauge.py
@@ -5,11 +5,11 @@ and functions relating to those tables
 """
 from pathlib import Path #used to read config.txt in parent directory
 from sqlalchemy import create_engine
-from sqlalchemy import Boolean, Column, Integer, String
+from sqlalchemy import BigInteger, Boolean, Column, Integer, String
 from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION, TIMESTAMP
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.sql import func
-# from sqlalchemy.schema import ForeignKey
+from sqlalchemy.schema import ForeignKey
 from sqlalchemy.types import Enum
 
 import configparser
@@ -48,10 +48,10 @@ class Reading(BASE):
     __tablename__ = 'reading'
 
     datetime = Column(TIMESTAMP, primary_key=True)
-    purpose_id = Column(Integer, primary_key=True)
-    units = Column(String)
-    reading = Column(DOUBLE_PRECISION)
-    upload_timestamp = Column(TIMESTAMP, default=func.now())
+    purpose_id = Column(BigInteger, ForeignKey('sensor_info.purpose_id'), primary_key=True)
+    units = Column(String(length=255), nullable=False)
+    reading = Column(DOUBLE_PRECISION, nullable=False)
+    upload_timestamp = Column(TIMESTAMP, default=func.now(), nullable=False)
 
 
 class SensorInfo(BASE):
@@ -79,16 +79,16 @@ class SensorInfo(BASE):
         webctrl = "webctrl"
 
     purpose_id = Column(Integer, primary_key=True)
-    building = Column(String)
-    variable_name = Column(String)
-    unit = Column(String)
-    type = Column(String)
-    appliance = Column(String)
-    room = Column(String)
-    surface = Column(String)
-    sample_resolution = Column(String)
-    query_string = Column(String)
-    note = Column(String)
+    building = Column(String(length=50))
+    variable_name = Column(String(length=50))
+    unit = Column(String(length=20))
+    type = Column(String(length=50))
+    appliance = Column(String(length=30))
+    room = Column(String(length=30))
+    surface = Column(String(length=50))
+    sample_resolution = Column(String(length=20))
+    query_string = Column(String(length=255))
+    note = Column(String(length=255))
     data_sensor_info_mapping = Column(String)
     script_folder = Column(Enum(ScriptFolderEnum))
     is_active = Column(Boolean)

--- a/egauge/script/orm_egauge.py
+++ b/egauge/script/orm_egauge.py
@@ -60,17 +60,17 @@ class SensorInfo(BASE):
 
     Columns:
         purpose_id: uniquely identifies a purpose
-        sensor_id: string used in egauge and webctrl API requests; hobo sensor serial number; one sensor_id may have multiple purposes (egauge)
+        query_string: string used in egauge and webctrl API requests; hobo sensor serial number; one query_string may have multiple purposes (egauge)
         data_sensor_info_mapping: matches full column name in raw data (egauge api data, hobo csv's, etc)
-        sensor_part: string that represents one column name in data from a sensor if one row of data has multiple readings
-        sensor_type: string representing source of readings; e.g. egauge, webctrl, hobo
+        type: string that represents one column name in data from a sensor if one row of data has multiple readings
+        script_folder: string representing source of readings; e.g. egauge, webctrl, hobo
         is_active: boolean representing if script can request data from a sensor
         last_updated_datetime: used to keep track of datetime of last successfully inserted reading
-        units: unit of readings
+        unit: unit of readings
     """
     __tablename__ = 'sensor_info'
 
-    class SensorTypeEnum(enum.Enum):
+    class ScriptFolderEnum(enum.Enum):
         """
         This class defines strings that could be inserted into sensor_info.sensor_type
         """
@@ -79,13 +79,13 @@ class SensorInfo(BASE):
         webctrl = "webctrl"
 
     purpose_id = Column(Integer, primary_key=True)
-    sensor_id = Column(String)
+    query_string = Column(String)
     data_sensor_info_mapping = Column(String)
-    sensor_part = Column(String)
-    sensor_type = Column(Enum(SensorTypeEnum))
+    type = Column(String)
+    script_folder = Column(Enum(ScriptFolderEnum))
     is_active = Column(Boolean)
     last_updated_datetime = Column(TIMESTAMP)
-    units = Column(String)
+    unit = Column(String)
 
 
 class ErrorLog(BASE):
@@ -198,5 +198,5 @@ def teardown():
 #         outcsv = csv.writer(outfile)
 #         rows = session.query(Reading)
 #         for row in rows:
-#             outcsv.writerow([row.reading_id, row.sensor_id, row.timestamp, row.units, row.reading])
+#             outcsv.writerow([row.reading_id, row.query_string, row.timestamp, row.units, row.reading])
 #     session.close()

--- a/egauge/script/orm_egauge.py
+++ b/egauge/script/orm_egauge.py
@@ -108,7 +108,7 @@ class ErrorLog(BASE):
         log_id: uniquely identifies a row
         purpose_id: unique id representing a purpose
         datetime: when an api request or a reading insertion was attempted
-        status: boolean representing if api script ran successfully or not
+        was_success: boolean representing if api script ran successfully or not
         error_type: name of python exception caught; should remain empty if no exception was caught
         pipeline_stage: the stage of the api script execution when an error_log row was inserted
     """
@@ -129,7 +129,7 @@ class ErrorLog(BASE):
     log_id = Column(Integer, primary_key=True)
     purpose_id = Column(Integer)
     datetime = Column(TIMESTAMP)
-    status = Column(Boolean)
+    was_success = Column(Boolean)
     error_type = Column(String)
     pipeline_stage = Column(Enum(PipelineStageEnum))
 

--- a/egauge/script/test_egauge.py
+++ b/egauge/script/test_egauge.py
@@ -22,7 +22,7 @@ class TestEgaugeAPI(unittest.TestCase):
 
     Currently has tests for get_data_from_api()
     """
-    sensor_id = 'egauge791'
+    query_string = 'egauge791'
     db_url = 'postgresql:///test'
 
 
@@ -45,23 +45,23 @@ class TestEgaugeAPI(unittest.TestCase):
         # Shift timestamp back by 60 seconds when inserting table
         # because get_data_from_api() will use timestamp + 60 seconds
         # for the start time in its api request.
-        sensor_row = orm_egauge.SensorInfo(sensor_id=self.sensor_id, sensor_type="egauge", purpose_id=1, sensor_part="Usage [kW]", last_updated_datetime=timestamps[0].subtract(seconds=60), is_active=True)
+        sensor_row = orm_egauge.SensorInfo(query_string=self.query_string, script_folder="egauge", purpose_id=1, data_sensor_info_mapping="Usage [kW]", last_updated_datetime=timestamps[0].subtract(seconds=60), is_active=True)
         conn.add(sensor_row)
         conn.commit()
         # get_data_from_api() adds 60 seconds to api_start_timestamp arg when making egauge api call
         frozen_time1 = timestamps[1]
         with freeze_time(time_to_freeze=frozen_time1):
-            reading_dataframe1, purpose_sensors = api_egauge.get_data_from_api(conn, self.sensor_id)
+            reading_dataframe1, purpose_sensors = api_egauge.get_data_from_api(conn, self.query_string)
         index1 = pandas.Index(reading_dataframe1['Date & Time'])
         #print contents of Date & Time column for visual verification if test fails
         print(index1)
         # reading_dataframe1.to_csv(path_or_buf='test_output.log', mode='a+')
 
-        conn.query(orm_egauge.SensorInfo.purpose_id).filter(orm_egauge.SensorInfo.sensor_id == self.sensor_id).update({"last_updated_datetime": timestamps[1].subtract(seconds=60)})
+        conn.query(orm_egauge.SensorInfo.purpose_id).filter(orm_egauge.SensorInfo.query_string == self.query_string).update({"last_updated_datetime": timestamps[1].subtract(seconds=60)})
         conn.commit()
         frozen_time2 = timestamps[2]
         with freeze_time(time_to_freeze=frozen_time2):
-            reading_dataframe2, purpose_sensors = api_egauge.get_data_from_api(conn, self.sensor_id)
+            reading_dataframe2, purpose_sensors = api_egauge.get_data_from_api(conn, self.query_string)
         index2 = pandas.Index(reading_dataframe2['Date & Time'])
         print(index2)
         # reading_dataframe2.to_csv(path_or_buf='test_output.log', mode='a+')
@@ -81,12 +81,12 @@ class TestEgaugeAPI(unittest.TestCase):
         start_timestamp = pendulum.parse('2019-02-01T00:00:00.000-10:00')
         end_timestamp = pendulum.parse('2019-02-01T00:15:44.100-10:00')
         #insert start_timestamp into database_insertion_timestamp
-        sensor_row = orm_egauge.SensorInfo(sensor_id=self.sensor_id, sensor_type="egauge", purpose_id=1, sensor_part="Usage [kW]", last_updated_datetime=start_timestamp.subtract(seconds=60), is_active=True)
+        sensor_row = orm_egauge.SensorInfo(query_string=self.query_string, script_folder="egauge", purpose_id=1, data_sensor_info_mapping="Usage [kW]", last_updated_datetime=start_timestamp.subtract(seconds=60), is_active=True)
         conn.add(sensor_row)
         conn.commit()
         frozen_time = end_timestamp
         with freeze_time(time_to_freeze=frozen_time):
-            reading_dataframe, purpose_sensors = api_egauge.get_data_from_api(conn, self.sensor_id)
+            reading_dataframe, purpose_sensors = api_egauge.get_data_from_api(conn, self.query_string)
         index = pandas.Index(reading_dataframe['Date & Time'])
         print(index)
         # get the difference in minutes between the start and end time

--- a/hobo/script/extract_hobo.py
+++ b/hobo/script/extract_hobo.py
@@ -112,8 +112,8 @@ def get_csv_from_folder_not_in_db(conn, csv_filename):
         conn.add(latest_csv_timestamp_row)
     # check if earliest and latest file_timestamps are already in db and set new_readings variable
     # assume that if first or last timestamps in csv were already inserted for that given timestamp and query_string, then all were already inserted
-    earliest_csv_timestamp_is_in_db = conn.query(orm_hobo.Readings).filter_by(datetime=earliest_csv_timestamp, purpose_id=sensor_info_rows[0].purpose_id).first()
-    latest_csv_timestamp_is_in_db = conn.query(orm_hobo.Readings).filter_by(datetime=latest_csv_timestamp, purpose_id=sensor_info_rows[0].purpose_id).first()
+    earliest_csv_timestamp_is_in_db = conn.query(orm_hobo.Reading).filter_by(datetime=earliest_csv_timestamp, purpose_id=sensor_info_rows[0].purpose_id).first()
+    latest_csv_timestamp_is_in_db = conn.query(orm_hobo.Reading).filter_by(datetime=latest_csv_timestamp, purpose_id=sensor_info_rows[0].purpose_id).first()
     if not earliest_csv_timestamp_is_in_db and not latest_csv_timestamp_is_in_db:
         new_readings = True
     return csv_readings, (new_readings, earliest_csv_timestamp, csv_modified_timestamp, query_string, latest_csv_timestamp, sensor_info_rows)
@@ -146,7 +146,7 @@ def insert_csv_readings_into_db(conn, csv_readings, csv_metadata, csv_filename):
     if rows_returned > 0:
         for csv_reading in csv_readings.itertuples():
             for i in range(0, len(sensor_info_rows)):
-                reading_row = orm_hobo.Readings(datetime=csv_reading[1], purpose_id=sensor_info_rows[i].purpose_id, value=csv_reading[i+2], units=sensor_info_rows[i].unit)
+                reading_row = orm_hobo.Reading(datetime=csv_reading[1], purpose_id=sensor_info_rows[i].purpose_id, reading=csv_reading[i+2], units=sensor_info_rows[i].unit)
                 conn.add(reading_row)
             last_reading_row_datetime = csv_reading[1]
     #update last_updated_datetime column for relevant rows in sensor_info table

--- a/hobo/script/orm_hobo.py
+++ b/hobo/script/orm_hobo.py
@@ -31,7 +31,7 @@ class Project(BASE):
     project_folder_path = Column(String, primary_key=True)
 
 
-class Readings(BASE):
+class Reading(BASE):
     """
     This class represents the readings table
 
@@ -42,11 +42,11 @@ class Readings(BASE):
         purpose_id: unique id representing a purpose
         value: the numerical value of a reading
     """
-    __tablename__ = 'readings'
+    __tablename__ = 'reading'
 
     datetime = Column(TIMESTAMP, primary_key=True)
     purpose_id = Column(Integer, primary_key=True)
-    value = Column(DOUBLE_PRECISION)
+    reading = Column(DOUBLE_PRECISION)
     units = Column(String)
     upload_timestamp = Column(TIMESTAMP, default=func.now())
 
@@ -76,13 +76,20 @@ class SensorInfo(BASE):
         webctrl = "webctrl"
 
     purpose_id = Column(Integer, primary_key=True)
-    query_string = Column(String)
-    data_sensor_info_mapping = Column(String)
+    building = Column(String)
+    variable_name = Column(String)
+    unit = Column(String)
     type = Column(String)
+    appliance = Column(String)
+    room = Column(String)
+    surface = Column(String)
+    sample_resolution = Column(String)
+    query_string = Column(String)
+    note = Column(String)
+    data_sensor_info_mapping = Column(String)
     script_folder = Column(Enum(ScriptFolderEnum))
     is_active = Column(Boolean)
     last_updated_datetime = Column(TIMESTAMP)
-    unit = Column(String)
 
 
 class ErrorLog(BASE):

--- a/hobo/script/orm_hobo.py
+++ b/hobo/script/orm_hobo.py
@@ -57,17 +57,17 @@ class SensorInfo(BASE):
 
     Columns:
         purpose_id: uniquely identifies a purpose
-        sensor_id: string used in egauge and webctrl API requests; hobo sensor serial number; one sensor_id may have multiple purposes (egauge)
+        query_string: string used in egauge and webctrl API requests; hobo sensor serial number; one query_string may have multiple purposes (egauge)
         data_sensor_info_mapping: matches full column name in raw data (egauge api data, hobo csv's, etc)
-        sensor_part: string that represents one column name in data from a sensor if one row of data has multiple readings
-        sensor_type: string representing source of readings; e.g. egauge, webctrl, hobo
+        type: string that represents one column name in data from a sensor if one row of data has multiple readings
+        script_folder: string representing source of readings; e.g. egauge, webctrl, hobo
         is_active: boolean representing if script can request data from a sensor
         last_updated_datetime: used to keep track of datetime of last successfully inserted reading
-        units: unit of readings
+        unit: unit of readings
     """
     __tablename__ = 'sensor_info'
 
-    class SensorTypeEnum(enum.Enum):
+    class ScriptFolderEnum(enum.Enum):
         """
         This class defines strings that could be inserted into sensor_info.sensor_type
         """
@@ -76,13 +76,13 @@ class SensorInfo(BASE):
         webctrl = "webctrl"
 
     purpose_id = Column(Integer, primary_key=True)
-    sensor_id = Column(String)
+    query_string = Column(String)
     data_sensor_info_mapping = Column(String)
-    sensor_part = Column(String)
-    sensor_type = Column(Enum(SensorTypeEnum))
+    type = Column(String)
+    script_folder = Column(Enum(ScriptFolderEnum))
     is_active = Column(Boolean)
     last_updated_datetime = Column(TIMESTAMP)
-    units = Column(String)
+    unit = Column(String)
 
 
 class ErrorLog(BASE):

--- a/hobo/script/orm_hobo.py
+++ b/hobo/script/orm_hobo.py
@@ -105,7 +105,7 @@ class ErrorLog(BASE):
         log_id: uniquely identifies a row
         purpose_id: unique id representing a purpose
         datetime: when an api request or a reading insertion was attempted
-        status: boolean representing if api script ran successfully or not
+        was_success: boolean representing if api script ran successfully or not
         error_type: name of python exception caught; should remain empty if no exception was caught
         pipeline_stage: the stage of the api script execution when an error_log row was inserted
     """
@@ -126,7 +126,7 @@ class ErrorLog(BASE):
     log_id = Column(Integer, primary_key=True)
     purpose_id = Column(Integer)
     datetime = Column(TIMESTAMP)
-    status = Column(Boolean)
+    was_success = Column(Boolean)
     error_type = Column(String)
     pipeline_stage = Column(Enum(PipelineStageEnum))
 

--- a/hobo/script/orm_hobo.py
+++ b/hobo/script/orm_hobo.py
@@ -4,9 +4,10 @@ and functions relating to those tables
 """
 from pathlib import Path
 from sqlalchemy import create_engine
-from sqlalchemy import Boolean, Column, Integer, String
+from sqlalchemy import BigInteger, Boolean, Column, Integer, String
 from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION, TIMESTAMP
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.schema import ForeignKey
 from sqlalchemy.sql import func
 from sqlalchemy.types import Enum
 
@@ -45,10 +46,10 @@ class Reading(BASE):
     __tablename__ = 'reading'
 
     datetime = Column(TIMESTAMP, primary_key=True)
-    purpose_id = Column(Integer, primary_key=True)
-    reading = Column(DOUBLE_PRECISION)
-    units = Column(String)
-    upload_timestamp = Column(TIMESTAMP, default=func.now())
+    purpose_id = Column(BigInteger, ForeignKey('sensor_info.purpose_id'), primary_key=True)
+    units = Column(String(length=255), nullable=False)
+    reading = Column(DOUBLE_PRECISION, nullable=False)
+    upload_timestamp = Column(TIMESTAMP, default=func.now(), nullable=False)
 
 
 class SensorInfo(BASE):
@@ -76,16 +77,16 @@ class SensorInfo(BASE):
         webctrl = "webctrl"
 
     purpose_id = Column(Integer, primary_key=True)
-    building = Column(String)
-    variable_name = Column(String)
-    unit = Column(String)
-    type = Column(String)
-    appliance = Column(String)
-    room = Column(String)
-    surface = Column(String)
-    sample_resolution = Column(String)
-    query_string = Column(String)
-    note = Column(String)
+    building = Column(String(length=50))
+    variable_name = Column(String(length=50))
+    unit = Column(String(length=20))
+    type = Column(String(length=50))
+    appliance = Column(String(length=30))
+    room = Column(String(length=30))
+    surface = Column(String(length=50))
+    sample_resolution = Column(String(length=20))
+    query_string = Column(String(length=255))
+    note = Column(String(length=255))
     data_sensor_info_mapping = Column(String)
     script_folder = Column(Enum(ScriptFolderEnum))
     is_active = Column(Boolean)

--- a/init_crontab.py
+++ b/init_crontab.py
@@ -34,27 +34,27 @@ if __name__=='__main__':
             # update crontab with removal
             cron.write()
 
-    # create a list with each unique sensor type
-    sensor_types = [stype[0] for stype in conn.query(orm_egauge.SensorInfo.sensor_type).filter(orm_egauge.SensorInfo.is_active==True).distinct()]
-    print(__file__ + ': extracted active sensor types ', str(sensor_types), ' from database')
+    # create a list with each unique script folder that is not set to None
+    script_folders = [stype[0] for stype in conn.query(orm_egauge.SensorInfo.script_folder).filter(orm_egauge.SensorInfo.is_active==True).distinct() if stype[0]]
+    print(__file__ + ': extracted active script folders ', str(script_folders), ' from database')
 
-    for sensor_type in sensor_types:
-        #use ".value" to access value of sensor_type enum
-        sensor_type = sensor_type.value
+    for script_folder in script_folders:
+        # use ".value" to access value of script_folder enum
+        script_folder = script_folder.value
         # hobo has a different script name
-        if sensor_type == 'hobo':
+        if script_folder == 'hobo':
             sensor_scriptname = 'extract_hobo.py'
         else:
-            sensor_scriptname = 'api_' + sensor_type + '.py'
+            sensor_scriptname = 'api_' + script_folder + '.py'
 
         # command should cd to the appropriate */script directory, then run the script
         # and write outputs to crontab.txt in the */script directory
-        job = cron.new(command='cd ' + project_path + '/' + sensor_type + '/script && ' + \
+        job = cron.new(command='cd ' + project_path + '/' + script_folder + '/script && ' + \
                                'python3 ' + sensor_scriptname + ' >> crontab.txt')
 
         # set crontab jobs to run every five minutes
         job.minute.every(5)
-        print(__file__ + ': attempting to write ' + sensor_type + ' job to crontab')
+        print(__file__ + ': attempting to write ' + script_folder + ' job to crontab')
         cron.write()
 
     conn.close()

--- a/init_database.py
+++ b/init_database.py
@@ -56,6 +56,12 @@ if __name__ == '__main__':
             conn.add(project_row)
         else:
             print(__file__ + ': project_folder_path ' + project_folder_path + ' already exists in project table')
+        #cast timestamp fields to timestamp(6) to limit timestamp precision to the hundredth second
+        conn.execute('ALTER TABLE reading ALTER COLUMN datetime TYPE timestamp(6);')
+        conn.execute('ALTER TABLE reading ALTER COLUMN upload_timestamp TYPE timestamp(6);')
+        conn.execute('ALTER TABLE reading ALTER COLUMN upload_timestamp SET DEFAULT NOW();')
+        conn.execute('ALTER TABLE sensor_info ALTER COLUMN last_updated_datetime TYPE timestamp(6);')
+        conn.execute('ALTER TABLE error_log ALTER COLUMN datetime TYPE timestamp(6);')
         conn.commit()
         conn.close()
 

--- a/webctrl/script/api_webctrl.py
+++ b/webctrl/script/api_webctrl.py
@@ -115,7 +115,7 @@ def insert_readings_into_database(conn, readings, sensor):
                 reading_value = reading[key]
         # subtract 10 hours from reading time for comparison because it's GMT and last_updated_datetime is GMT - 10
         if reading_time.subtract(hours=10) > pendulum.instance(sensor.last_updated_datetime):
-            reading_row = orm_webctrl.Readings(purpose_id=sensor.purpose_id, datetime=reading_time, value=reading_value, units=sensor.unit)
+            reading_row = orm_webctrl.Reading(purpose_id=sensor.purpose_id, datetime=reading_time, reading=reading_value, units=sensor.unit)
             conn.add(reading_row)
             rows_inserted += 1
             new_last_updated_datetime = reading_time

--- a/webctrl/script/api_webctrl.py
+++ b/webctrl/script/api_webctrl.py
@@ -52,7 +52,7 @@ def get_data_from_api(sensor, conn):
     2. send request to webctrl api and attempt to download the readings data
 
     3. generate timestamp of data request
-    4. use sensor.purpose_id to insert success or failure status in error_log
+    4. use sensor.purpose_id to insert success or failure was_success in error_log
     """
     current_time = pendulum.now('Pacific/Honolulu')
     # if no timestamp is found, raise exception
@@ -75,7 +75,7 @@ def get_data_from_api(sensor, conn):
     readings = requests.post(host, params=params, auth=tuple(auth))
     if readings.status_code == requests.codes.ok:
         print('API request was successful' + str(readings))
-        error_log_row = orm_webctrl.ErrorLog(datetime=current_time, status=True, purpose_id=sensor.purpose_id, pipeline_stage=orm_webctrl.ErrorLog.PipelineStageEnum.data_acquisition)
+        error_log_row = orm_webctrl.ErrorLog(datetime=current_time, was_success=True, purpose_id=sensor.purpose_id, pipeline_stage=orm_webctrl.ErrorLog.PipelineStageEnum.data_acquisition)
         conn.add(error_log_row)
         conn.commit()
         return readings
@@ -125,7 +125,7 @@ def insert_readings_into_database(conn, readings, sensor):
     if new_last_updated_datetime:
         conn.query(orm_webctrl.SensorInfo).filter(orm_webctrl.SensorInfo.purpose_id == sensor.purpose_id).update(
             {"last_updated_datetime": new_last_updated_datetime})
-    error_log_row = orm_webctrl.ErrorLog(datetime=current_time, status=True, purpose_id=sensor.purpose_id, pipeline_stage=orm_webctrl.ErrorLog.PipelineStageEnum.database_insertion)
+    error_log_row = orm_webctrl.ErrorLog(datetime=current_time, was_success=True, purpose_id=sensor.purpose_id, pipeline_stage=orm_webctrl.ErrorLog.PipelineStageEnum.database_insertion)
     conn.add(error_log_row)
     conn.commit()
     print(rows_inserted, ' row(s) inserted')
@@ -135,7 +135,7 @@ def insert_readings_into_database(conn, readings, sensor):
 def log_failure_to_connect_to_api(conn, exception, sensor):
     current_time = pendulum.now('Pacific/Honolulu')
     logging.exception('log_failure_to_connect_to_api')
-    error_log_row = orm_webctrl.ErrorLog(datetime=current_time, error_type=exception.__class__.__name__, pipeline_stage=orm_webctrl.ErrorLog.PipelineStageEnum.data_acquisition, purpose_id=sensor.purpose_id, status=False)
+    error_log_row = orm_webctrl.ErrorLog(datetime=current_time, error_type=exception.__class__.__name__, pipeline_stage=orm_webctrl.ErrorLog.PipelineStageEnum.data_acquisition, purpose_id=sensor.purpose_id, was_success=False)
     conn.add(error_log_row)
     conn.commit()
 
@@ -146,7 +146,7 @@ def log_failure_to_connect_to_database(conn, exception, sensor):
     conn.rollback()
     current_time = pendulum.now('Pacific/Honolulu')
     logging.exception('log_failure_to_connect_to_database')
-    error_log_row = orm_webctrl.ErrorLog(datetime=current_time, error_type=exception.__class__.__name__, pipeline_stage=orm_webctrl.ErrorLog.PipelineStageEnum.database_insertion, purpose_id=sensor.purpose_id, status=False)
+    error_log_row = orm_webctrl.ErrorLog(datetime=current_time, error_type=exception.__class__.__name__, pipeline_stage=orm_webctrl.ErrorLog.PipelineStageEnum.database_insertion, purpose_id=sensor.purpose_id, was_success=False)
     conn.add(error_log_row)
     conn.commit()
 

--- a/webctrl/script/orm_webctrl.py
+++ b/webctrl/script/orm_webctrl.py
@@ -59,17 +59,17 @@ class SensorInfo(BASE):
 
     Columns:
         purpose_id: uniquely identifies a purpose
-        sensor_id: string used in egauge and webctrl API requests; hobo sensor serial number; one sensor_id may have multiple purposes (egauge)
+        query_string: string used in egauge and webctrl API requests; hobo sensor serial number; one query_string may have multiple purposes (egauge)
         data_sensor_info_mapping: matches full column name in raw data (egauge api data, hobo csv's, etc)
-        sensor_part: string that represents one column name in data from a sensor if one row of data has multiple readings
-        sensor_type: string representing source of readings; e.g. egauge, webctrl, hobo
+        type: string that represents one column name in data from a sensor if one row of data has multiple readings
+        script_folder: string representing source of readings; e.g. egauge, webctrl, hobo
         is_active: boolean representing if script can request data from a sensor
         last_updated_datetime: used to keep track of datetime of last successfully inserted reading
-        units: unit of readings
+        unit: unit of readings
     """
     __tablename__ = 'sensor_info'
 
-    class SensorTypeEnum(enum.Enum):
+    class ScriptFolderEnum(enum.Enum):
         """
         This class defines strings that could be inserted into sensor_info.sensor_type
         """
@@ -78,13 +78,13 @@ class SensorInfo(BASE):
         webctrl = "webctrl"
 
     purpose_id = Column(Integer, primary_key=True)
-    sensor_id = Column(String)
+    query_string = Column(String)
     data_sensor_info_mapping = Column(String)
-    sensor_part = Column(String)
-    sensor_type = Column(Enum(SensorTypeEnum))
+    type = Column(String)
+    script_folder = Column(Enum(ScriptFolderEnum))
     is_active = Column(Boolean)
     last_updated_datetime = Column(TIMESTAMP)
-    units = Column(String)
+    unit = Column(String)
 
 
 class ErrorLog(BASE):

--- a/webctrl/script/orm_webctrl.py
+++ b/webctrl/script/orm_webctrl.py
@@ -107,7 +107,7 @@ class ErrorLog(BASE):
         log_id: uniquely identifies a row
         purpose_id: unique id representing a purpose
         datetime: when an api request or a reading insertion was attempted
-        status: boolean representing if api script ran successfully or not
+        was_success: boolean representing if api script ran successfully or not
         error_type: name of python exception caught; should remain empty if no exception was caught
         pipeline_stage: the stage of the api script execution when an error_log row was inserted
     """
@@ -128,7 +128,7 @@ class ErrorLog(BASE):
     log_id = Column(Integer, primary_key=True)
     purpose_id = Column(Integer)
     datetime = Column(TIMESTAMP)
-    status = Column(Boolean)
+    was_success = Column(Boolean)
     error_type = Column(String)
     pipeline_stage = Column(Enum(PipelineStageEnum))
 

--- a/webctrl/script/orm_webctrl.py
+++ b/webctrl/script/orm_webctrl.py
@@ -33,7 +33,7 @@ class Project(BASE):
     project_folder_path = Column(String, primary_key=True)
 
 
-class Readings(BASE):
+class Reading(BASE):
     """
     This class represents the readings table
 
@@ -44,11 +44,11 @@ class Readings(BASE):
         purpose_id: unique id representing a purpose
         value: the numerical value of a reading
     """
-    __tablename__ = 'readings'
+    __tablename__ = 'reading'
 
     datetime = Column(TIMESTAMP, primary_key=True)
     purpose_id = Column(Integer, primary_key=True)
-    value = Column(DOUBLE_PRECISION)
+    reading = Column(DOUBLE_PRECISION)
     units = Column(String)
     upload_timestamp = Column(TIMESTAMP, default=func.now())
 
@@ -78,13 +78,20 @@ class SensorInfo(BASE):
         webctrl = "webctrl"
 
     purpose_id = Column(Integer, primary_key=True)
-    query_string = Column(String)
-    data_sensor_info_mapping = Column(String)
+    building = Column(String)
+    variable_name = Column(String)
+    unit = Column(String)
     type = Column(String)
+    appliance = Column(String)
+    room = Column(String)
+    surface = Column(String)
+    sample_resolution = Column(String)
+    query_string = Column(String)
+    note = Column(String)
+    data_sensor_info_mapping = Column(String)
     script_folder = Column(Enum(ScriptFolderEnum))
     is_active = Column(Boolean)
     last_updated_datetime = Column(TIMESTAMP)
-    unit = Column(String)
 
 
 class ErrorLog(BASE):

--- a/webctrl/script/orm_webctrl.py
+++ b/webctrl/script/orm_webctrl.py
@@ -4,10 +4,10 @@ and functions relating to those tables
 """
 from pathlib import Path #used to read config.txt in parent directory
 from sqlalchemy import create_engine
-from sqlalchemy import Boolean, Column, Integer, String
+from sqlalchemy import BigInteger, Boolean, Column, Integer, String
 from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION, TIMESTAMP
 from sqlalchemy.ext.declarative import declarative_base
-# from sqlalchemy.schema import ForeignKey
+from sqlalchemy.schema import ForeignKey
 from sqlalchemy.sql import func
 from sqlalchemy.types import Enum
 
@@ -47,10 +47,10 @@ class Reading(BASE):
     __tablename__ = 'reading'
 
     datetime = Column(TIMESTAMP, primary_key=True)
-    purpose_id = Column(Integer, primary_key=True)
-    reading = Column(DOUBLE_PRECISION)
-    units = Column(String)
-    upload_timestamp = Column(TIMESTAMP, default=func.now())
+    purpose_id = Column(BigInteger, ForeignKey('sensor_info.purpose_id'), primary_key=True)
+    units = Column(String(length=255), nullable=False)
+    reading = Column(DOUBLE_PRECISION, nullable=False)
+    upload_timestamp = Column(TIMESTAMP, default=func.now(), nullable=False)
 
 
 class SensorInfo(BASE):
@@ -78,16 +78,16 @@ class SensorInfo(BASE):
         webctrl = "webctrl"
 
     purpose_id = Column(Integer, primary_key=True)
-    building = Column(String)
-    variable_name = Column(String)
-    unit = Column(String)
-    type = Column(String)
-    appliance = Column(String)
-    room = Column(String)
-    surface = Column(String)
-    sample_resolution = Column(String)
-    query_string = Column(String)
-    note = Column(String)
+    building = Column(String(length=50))
+    variable_name = Column(String(length=50))
+    unit = Column(String(length=20))
+    type = Column(String(length=50))
+    appliance = Column(String(length=30))
+    room = Column(String(length=30))
+    surface = Column(String(length=50))
+    sample_resolution = Column(String(length=20))
+    query_string = Column(String(length=255))
+    note = Column(String(length=255))
     data_sensor_info_mapping = Column(String)
     script_folder = Column(Enum(ScriptFolderEnum))
     is_active = Column(Boolean)


### PR DESCRIPTION
Related issue #101

Rename columns in sensor_info table to match column names in scrape-util database for compatibility with Eileen's views.
- renamed units to unit
- renamed sensor_part to type
- renamed sensor_id to query_string
- renamed sensor_type to script_folder
   - update init_crontab to use script_folder