### PR TITLE
Add python3 requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+freezegun==0.3.10  #new
+pandas==0.20.2
+pendulum==2.0.3   #new
+psycopg2==2.7.1
+python-crontab==2.3.6   #new
+requests==2.9.1
+SQLAlchemy==1.1.10
+urllib3==1.13.1


### PR DESCRIPTION
Related issue #107

requirements.txt includes all python3 modules needed to run this project.
This file will be useful for initial setup of lonoa on a system.
- install modules from this file using command ```pip3 install -r requirements.txt```

Lines in file marked #new are modules that were not previously installed on sea-vm