### PR TITLE
Add script_folder column to api_authentication table

### DIFF
--- a/egauge/script/orm_egauge.py
+++ b/egauge/script/orm_egauge.py
@@ -157,11 +157,12 @@ class ApiAuthentication(BASE):
     """
     User info for authentication
 
-    Currently used to connect to webctrl api
+    Used when connecting to api's like webctrl
     """
     __tablename__ = 'api_authentication'
 
     user_id = Column(Integer, primary_key=True)
+    script_folder = Column(Enum(SensorInfo.ScriptFolderEnum))
     username = Column(String)
     password = Column(String)
 

--- a/hobo/script/orm_hobo.py
+++ b/hobo/script/orm_hobo.py
@@ -151,11 +151,12 @@ class ApiAuthentication(BASE):
     """
     User info for authentication
 
-    Currently used to connect to webctrl api
+    Used when connecting to api's like webctrl
     """
     __tablename__ = 'api_authentication'
 
     user_id = Column(Integer, primary_key=True)
+    script_folder = Column(Enum(SensorInfo.ScriptFolderEnum))
     username = Column(String)
     password = Column(String)
 

--- a/webctrl/script/api_webctrl.py
+++ b/webctrl/script/api_webctrl.py
@@ -60,7 +60,7 @@ def get_data_from_api(sensor, conn):
     if not sensor.last_updated_datetime:
         raise Exception('No last_updated_datetime found')
     #get webctrl user information
-    webctrl_user_row = conn.query(orm_webctrl.ApiAuthentication.username, orm_webctrl.ApiAuthentication.password).first()
+    webctrl_user_row = conn.query(orm_webctrl.ApiAuthentication.username, orm_webctrl.ApiAuthentication.password).filter_by(script_folder=orm_webctrl.SensorInfo.ScriptFolderEnum.webctrl)[0]
     # returns a TypeError if there are no users in database
     api_user = webctrl_user_row[0]
     api_pass = webctrl_user_row[1]

--- a/webctrl/script/orm_webctrl.py
+++ b/webctrl/script/orm_webctrl.py
@@ -156,11 +156,12 @@ class ApiAuthentication(BASE):
     """
     User info for authentication
 
-    Currently used to connect to webctrl api
+    Used when connecting to api's like webctrl
     """
     __tablename__ = 'api_authentication'
 
     user_id = Column(Integer, primary_key=True)
+    script_folder = Column(Enum(SensorInfo.ScriptFolderEnum))
     username = Column(String)
     password = Column(String)
 


### PR DESCRIPTION
related issue #113

I added a script_folder column to the api_authentication table, since we discussed that other api's like egauge might also need a username and password for authentication.