### PR TITLE
Add log_id to reading table

### DIFF
--- a/egauge/script/orm_egauge.py
+++ b/egauge/script/orm_egauge.py
@@ -52,6 +52,7 @@ class Reading(BASE):
     units = Column(String(length=255), nullable=False)
     reading = Column(DOUBLE_PRECISION, nullable=False)
     upload_timestamp = Column(TIMESTAMP, default=func.now(), nullable=False)
+    log_id = Column(Integer, ForeignKey('error_log.log_id'))
 
 
 class SensorInfo(BASE):

--- a/hobo/script/extract_hobo.py
+++ b/hobo/script/extract_hobo.py
@@ -169,6 +169,11 @@ def insert_csv_readings_into_db(conn, csv_readings, csv_metadata, csv_filename):
         conn.add(earliest_csv_timestamp_row)
         latest_csv_timestamp_row = orm_hobo.ErrorLogDetails(log_id=error_log_row.log_id, information_type="latest_csv_timestamp", information_value=latest_csv_timestamp)
         conn.add(latest_csv_timestamp_row)
+        # update current sensor_info_row's set of readings with related log_id
+        conn.query(orm_hobo.Reading.log_id).\
+            filter(orm_hobo.Reading.purpose_id == sensor_info_row.purpose_id,
+                   orm_hobo.Reading.upload_timestamp == current_time).\
+            update({'log_id': error_log_row.log_id})
     conn.commit()
 
 

--- a/hobo/script/orm_hobo.py
+++ b/hobo/script/orm_hobo.py
@@ -50,6 +50,7 @@ class Reading(BASE):
     units = Column(String(length=255), nullable=False)
     reading = Column(DOUBLE_PRECISION, nullable=False)
     upload_timestamp = Column(TIMESTAMP, default=func.now(), nullable=False)
+    log_id = Column(Integer, ForeignKey('error_log.log_id'))
 
 
 class SensorInfo(BASE):

--- a/webctrl/script/orm_webctrl.py
+++ b/webctrl/script/orm_webctrl.py
@@ -51,6 +51,7 @@ class Reading(BASE):
     units = Column(String(length=255), nullable=False)
     reading = Column(DOUBLE_PRECISION, nullable=False)
     upload_timestamp = Column(TIMESTAMP, default=func.now(), nullable=False)
+    log_id = Column(Integer, ForeignKey('error_log.log_id'))
 
 
 class SensorInfo(BASE):


### PR DESCRIPTION
related issue #95

The egauge, webctrl, and hobo scripts now update sets of readings with their related error_log.log_ids after generating an error_log row.

Including log_ids with each reading should help make it easier to join readings with their related error_log row on the log_id for debugging.