### PR TITLE
Convert prints to logging using --verbose flag

### DIFF
--- a/egauge/script/api_egauge.py
+++ b/egauge/script/api_egauge.py
@@ -25,30 +25,38 @@ import requests
 
 
 SCRIPT_NAME = os.path.basename(__file__)
-# parser for script arguments
-parser = argparse.ArgumentParser(description='Get reading data from egauge api and insert into database.')
-#--verbose argument is True if set
-parser.add_argument('-v', '--verbose', action='store_true',
-                    help='print INFO level log messages to console and error.log')
-args = parser.parse_args()
 
-# set log level to INFO only if verbose is set
-if args.verbose:
-    log_level = 'INFO'
-else:
-    log_level = 'ERROR'
 
-# configure logger which will print log messages to console (only prints ERROR level messages by default; prints INFO level messages if --verbose flag is set)
-logging.basicConfig(level=log_level, format=__file__+': %(message)s')
+def set_logging_settings():
+    """
+    Sets logging to write ERROR messages by default to ./error.log and standard output
 
-# Create a handler that writes log messages to error.log file
-# rotates error.log every time it reaches 100 MB to limit space usage; keeps up to 5 old error.log files
-rotating_file_handler = logging.handlers.RotatingFileHandler('error.log', maxBytes=100000000, backupCount=5)
-# set the message and date format of file handler
-formatter = logging.Formatter(fmt='%(asctime)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')
-rotating_file_handler.setFormatter(formatter)
-# add the handler to the root logger
-logging.getLogger('').addHandler(rotating_file_handler)
+    Also writes INFO messages if there is a --verbose flag to ./error.log and standard output
+    """
+    # parser for script arguments like --verbose
+    parser = argparse.ArgumentParser(description='Get reading data from egauge api and insert into database.')
+    # --verbose argument is True if set
+    parser.add_argument('-v', '--verbose', action='store_true',
+                        help='print INFO level log messages to console and error.log')
+    args = parser.parse_args()
+
+    # set log level to INFO only if verbose is set
+    if args.verbose:
+        log_level = 'INFO'
+    else:
+        log_level = 'ERROR'
+
+    # configure logger which will print log messages to console (only prints ERROR level messages by default; prints INFO level messages if --verbose flag is set)
+    logging.basicConfig(level=log_level, format=__file__ + ': %(message)s')
+
+    # Create a handler that writes log messages to error.log file
+    # rotates error.log every time it reaches 100 MB to limit space usage; keeps up to 5 old error.log files
+    rotating_file_handler = logging.handlers.RotatingFileHandler('error.log', maxBytes=100000000, backupCount=5)
+    # set the message and date format of file handler
+    formatter = logging.Formatter(fmt='%(asctime)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')
+    rotating_file_handler.setFormatter(formatter)
+    # add the handler to the root logger
+    logging.getLogger('').addHandler(rotating_file_handler)
 
 
 # connect to database by creating a session
@@ -223,6 +231,7 @@ def log_failure_to_connect_to_database(conn, exception, purpose_sensors):
 
 
 if __name__ == '__main__':
+    set_logging_settings()
     # start the database connection
     conn = get_db_handler()
     # get a list of all unique query_string's for active egauges from sensor_info table

--- a/hobo/script/extract_hobo.py
+++ b/hobo/script/extract_hobo.py
@@ -3,17 +3,43 @@ from pathlib import Path
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+import argparse
 import configparser
 import csv
 import glob
 import logging
+import logging.handlers
 import orm_hobo
 import os
 import pandas
 import pendulum
 
 
-logging.basicConfig(filename='error.log', format='%(asctime)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')
+SCRIPT_NAME = os.path.basename(__file__)
+# parser for script arguments
+parser = argparse.ArgumentParser(description='Get reading data from egauge api and insert into database.')
+#--verbose argument is True if set
+parser.add_argument('-v', '--verbose', action='store_true',
+                    help='print INFO level log messages to console and error.log')
+args = parser.parse_args()
+
+# set log level to INFO only if verbose is set
+if args.verbose:
+    log_level = 'INFO'
+else:
+    log_level = 'ERROR'
+
+# configure logger which will print log messages to console (only prints ERROR level messages by default; prints INFO level messages if --verbose flag is set)
+logging.basicConfig(level=log_level, format=__file__+': %(message)s')
+
+# Create a handler that writes log messages to error.log file
+# rotates error.log every time it reaches 100 MB to limit space usage; keeps up to 5 old error.log files
+rotating_file_handler = logging.handlers.RotatingFileHandler('error.log', maxBytes=100000000, backupCount=5)
+# set the message and date format of file handler
+formatter = logging.Formatter(fmt='%(asctime)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')
+rotating_file_handler.setFormatter(formatter)
+# add the handler to the root logger
+logging.getLogger('').addHandler(rotating_file_handler)
 
 
 def get_db_handler():
@@ -136,14 +162,14 @@ def insert_csv_readings_into_db(conn, csv_readings, csv_metadata, csv_filename):
         if csv_readings.empty:
             return
         else:
-            print('readings extracted from csv')
+            logging.info('readings extracted from ' + csv_filename)
     #executes if not initialized as a dataframe
     elif not csv_readings:
         logging.exception('csv_readings set to None')
         return
     new_readings, earliest_csv_timestamp, csv_modified_timestamp, query_string, latest_csv_timestamp, sensor_info_rows = csv_metadata
     if not new_readings:
-        raise Exception("csv readings already inserted")
+        raise Exception('csv readings from ' + csv_filename + ' already inserted')
     rows_returned = csv_readings.shape[0]
     if rows_returned > 0:
         for csv_reading in csv_readings.itertuples():
@@ -153,6 +179,7 @@ def insert_csv_readings_into_db(conn, csv_readings, csv_metadata, csv_filename):
             last_reading_row_datetime = csv_reading[1]
     #update last_updated_datetime column for relevant rows in sensor_info table
     for sensor_info_row in sensor_info_rows:
+        logging.info('attempting to insert ' + str(rows_returned) + ' reading(s) for purpose_id ' + str(sensor_info_row.purpose_id))
         # account for if csv files uploaded out of order by checking if last_reading_row_datetime is later than last_updated_datetime
         if not sensor_info_row.last_updated_datetime or sensor_info_row.last_updated_datetime < last_reading_row_datetime:
             conn.query(orm_hobo.SensorInfo.purpose_id).filter(orm_hobo.SensorInfo.purpose_id == sensor_info_row.purpose_id).update({"last_updated_datetime": last_reading_row_datetime})

--- a/hobo/script/extract_hobo.py
+++ b/hobo/script/extract_hobo.py
@@ -16,30 +16,38 @@ import pendulum
 
 
 SCRIPT_NAME = os.path.basename(__file__)
-# parser for script arguments
-parser = argparse.ArgumentParser(description='Get reading data from egauge api and insert into database.')
-#--verbose argument is True if set
-parser.add_argument('-v', '--verbose', action='store_true',
-                    help='print INFO level log messages to console and error.log')
-args = parser.parse_args()
 
-# set log level to INFO only if verbose is set
-if args.verbose:
-    log_level = 'INFO'
-else:
-    log_level = 'ERROR'
 
-# configure logger which will print log messages to console (only prints ERROR level messages by default; prints INFO level messages if --verbose flag is set)
-logging.basicConfig(level=log_level, format=__file__+': %(message)s')
+def set_logging_settings():
+    """
+    Sets logging to write ERROR messages by default to ./error.log and standard output
 
-# Create a handler that writes log messages to error.log file
-# rotates error.log every time it reaches 100 MB to limit space usage; keeps up to 5 old error.log files
-rotating_file_handler = logging.handlers.RotatingFileHandler('error.log', maxBytes=100000000, backupCount=5)
-# set the message and date format of file handler
-formatter = logging.Formatter(fmt='%(asctime)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')
-rotating_file_handler.setFormatter(formatter)
-# add the handler to the root logger
-logging.getLogger('').addHandler(rotating_file_handler)
+    Also writes INFO messages if there is a --verbose flag to ./error.log and standard output
+    """
+    # parser for script arguments like --verbose
+    parser = argparse.ArgumentParser(description='Get reading data from hobo csv files in project\'s hobo/script/to-insert folder and insert into database.')
+    # --verbose argument is True if set
+    parser.add_argument('-v', '--verbose', action='store_true',
+                        help='print INFO level log messages to console and error.log')
+    args = parser.parse_args()
+
+    # set log level to INFO only if verbose is set
+    if args.verbose:
+        log_level = 'INFO'
+    else:
+        log_level = 'ERROR'
+
+    # configure logger which will print log messages to console (only prints ERROR level messages by default; prints INFO level messages if --verbose flag is set)
+    logging.basicConfig(level=log_level, format=__file__ + ': %(message)s')
+
+    # Create a handler that writes log messages to error.log file
+    # rotates error.log every time it reaches 100 MB to limit space usage; keeps up to 5 old error.log files
+    rotating_file_handler = logging.handlers.RotatingFileHandler('error.log', maxBytes=100000000, backupCount=5)
+    # set the message and date format of file handler
+    formatter = logging.Formatter(fmt='%(asctime)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')
+    rotating_file_handler.setFormatter(formatter)
+    # add the handler to the root logger
+    logging.getLogger('').addHandler(rotating_file_handler)
 
 
 def get_db_handler():
@@ -248,6 +256,7 @@ def log_failure_to_insert_csv_readings_into_db(conn, csv_filename, csv_metadata,
 
 
 if __name__=='__main__':
+    set_logging_settings()
     conn = get_db_handler()
     csv_filenames = glob.glob('./to-insert/*.csv')
     for csv_filename in csv_filenames:

--- a/init_crontab.py
+++ b/init_crontab.py
@@ -98,7 +98,7 @@ if __name__=='__main__':
             # and write outputs to crontab.txt in the */script directory
             script_folder = script_name.split('_')[1].split('.py')[0]
             job = cron.new(command='cd ' + project_path + '/' + script_folder + '/script && '
-                                   + 'python3 ' + script_name + ' >> crontab.txt')
+                                   + 'python3 ' + script_name)
         # schedule init_crontab job if not already scheduled
         else:
             job = cron.new(command='cd ' + project_path + '/ && python3 ' + str(script_name) + ' --min=' + str(args.min))

--- a/webctrl/script/api_webctrl.py
+++ b/webctrl/script/api_webctrl.py
@@ -21,30 +21,37 @@ import requests
 
 
 SCRIPT_NAME = os.path.basename(__file__)
-# parser for script arguments
-parser = argparse.ArgumentParser(description='Get reading data from egauge api and insert into database.')
-#--verbose argument is True if set
-parser.add_argument('-v', '--verbose', action='store_true',
-                    help='print INFO level log messages to console and error.log')
-args = parser.parse_args()
 
-# set log level to INFO only if verbose is set
-if args.verbose:
-    log_level = 'INFO'
-else:
-    log_level = 'ERROR'
+def set_logging_settings():
+    """
+    Sets logging to write ERROR messages by default to ./error.log and standard output
 
-# configure logger which will print log messages to console (only prints ERROR level messages by default; prints INFO level messages if --verbose flag is set)
-logging.basicConfig(level=log_level, format=__file__+': %(message)s')
+    Also writes INFO messages if there is a --verbose flag to ./error.log and standard output
+    """
+    # parser for script arguments like --verbose
+    parser = argparse.ArgumentParser(description='Get reading data from webctrl api and insert into database.')
+    # --verbose argument is True if set
+    parser.add_argument('-v', '--verbose', action='store_true',
+                        help='print INFO level log messages to console and error.log')
+    args = parser.parse_args()
 
-# Create a handler that writes log messages to error.log file
-# rotates error.log every time it reaches 100 MB to limit space usage; keeps up to 5 old error.log files
-rotating_file_handler = logging.handlers.RotatingFileHandler('error.log', maxBytes=100000000, backupCount=5)
-# set the message and date format of file handler
-formatter = logging.Formatter(fmt='%(asctime)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')
-rotating_file_handler.setFormatter(formatter)
-# add the handler to the root logger
-logging.getLogger('').addHandler(rotating_file_handler)
+    # set log level to INFO only if verbose is set
+    if args.verbose:
+        log_level = 'INFO'
+    else:
+        log_level = 'ERROR'
+
+    # configure logger which will print log messages to console (only prints ERROR level messages by default; prints INFO level messages if --verbose flag is set)
+    logging.basicConfig(level=log_level, format=__file__ + ': %(message)s')
+
+    # Create a handler that writes log messages to error.log file
+    # rotates error.log every time it reaches 100 MB to limit space usage; keeps up to 5 old error.log files
+    rotating_file_handler = logging.handlers.RotatingFileHandler('error.log', maxBytes=100000000, backupCount=5)
+    # set the message and date format of file handler
+    formatter = logging.Formatter(fmt='%(asctime)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')
+    rotating_file_handler.setFormatter(formatter)
+    # add the handler to the root logger
+    logging.getLogger('').addHandler(rotating_file_handler)
 
 
 # connect to database by creating a session
@@ -199,6 +206,7 @@ def log_failure_to_connect_to_database(conn, exception, sensor):
 
 
 if __name__ == '__main__':
+    set_logging_settings()
     # connect to the database
     conn = get_db_handler()
     sensors = conn.query(orm_webctrl.SensorInfo.purpose_id, orm_webctrl.SensorInfo.query_string, orm_webctrl.SensorInfo.last_updated_datetime, orm_webctrl.SensorInfo.unit).filter_by(script_folder=orm_webctrl.SensorInfo.ScriptFolderEnum.webctrl, is_active=True)


### PR DESCRIPTION
related issue #74

- converted print() statements to logging.info()
- added an argument flag '--verbose' or '-v' to  'api' and 'extract' scripts that enables those statements to be displayed in the console and written to error.log file
   - ERROR messages are printed to screen and written to error.log by default
   - usage example: ```python3 api_egauge.py --verbose```
- error.log now rotates to a new file when it reaches 100 MB
    - for each api/extract script up to 5 old error.log files are stored + current one to limit storage usage to <=600 MB/script
